### PR TITLE
Added spacing (&hairsp;) after Ӿ (and all currency symbols) for better readability; Added 'Matching send block' on receive blocks

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -470,6 +470,10 @@ body,
   color: rgba(0, 0, 0, 0.85);
 }
 
+.ant-statistic-content-prefix {
+  margin-right: 3px;
+}
+
 .ant-statistic-content-value-decimal {
   font-size: 16px;
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -193,6 +193,7 @@
       "sender": "Sender",
       "previousBlock": "Previous block",
       "successorBlock": "Successor block",
+      "matchingSendBlock": "Matching send block",
       "height": "Block height",
       "signature": "Signature",
       "work": "Work",

--- a/src/pages/Account/Delegators/index.tsx
+++ b/src/pages/Account/Delegators/index.tsx
@@ -109,7 +109,7 @@ const Delegators: React.FC = () => {
                         display: "block",
                       }}
                     >
-                      Ӿ{new BigNumber(weight).toFormat()}
+                      Ӿ {new BigNumber(weight).toFormat()}
                     </span>
                   </Col>
                   <Col xs={24} sm={12} md={16} lg={18}>

--- a/src/pages/Account/Details/index.tsx
+++ b/src/pages/Account/Details/index.tsx
@@ -174,7 +174,7 @@ const AccountDetails: React.FC<Props> = ({
               value={balance >= 1 ? balance : new BigNumber(balance).toFormat()}
             />
             <Skeleton {...skeletonProps}>
-              {`${CurrencySymbol?.[fiat]}${fiatBalance} / ${btcBalance} BTC`}
+              {`${CurrencySymbol?.[fiat]} ${fiatBalance} / ${btcBalance} BTC`}
             </Skeleton>
           </Col>
         </Row>
@@ -293,7 +293,7 @@ const AccountDetails: React.FC<Props> = ({
               </Tooltip>
             </Col>
             <Col xs={24} sm={18} md={20}>
-              <Skeleton {...skeletonProps}>Ӿ{balancePending}</Skeleton>
+              <Skeleton {...skeletonProps}>Ӿ {balancePending}</Skeleton>
             </Col>
           </Row>
         ) : null}

--- a/src/pages/Account/Transactions/index.tsx
+++ b/src/pages/Account/Transactions/index.tsx
@@ -222,7 +222,7 @@ const TransactionsTable = ({
                         ? t("common.notAvailable")
                         : ""}
                       {amount && amount !== "0"
-                        ? `Ӿ${new BigNumber(rawToRai(amount)).toFormat()}`
+                        ? `Ӿ ${new BigNumber(rawToRai(amount)).toFormat()}`
                         : ""}
                     </Text>
                   </Col>

--- a/src/pages/Block/Details/index.tsx
+++ b/src/pages/Block/Details/index.tsx
@@ -66,6 +66,7 @@ const BlockDetails: React.FC = () => {
     contents: {
       type = "",
       representative = "",
+      link = "",
       link_as_account: linkAsAccount = "",
       previous = "",
       signature = "",
@@ -217,7 +218,7 @@ const BlockDetails: React.FC = () => {
                   }
                   title={{ width: isSmallAndLower ? "100%" : "33%" }}
                 >
-                  {`${CurrencySymbol?.[fiat]}${fiatAmount} / ${btcAmount} BTC`}
+                  {`${CurrencySymbol?.[fiat]} ${fiatAmount} / ${btcAmount} BTC`}
                 </Skeleton>
               </Col>
             </Row>
@@ -230,7 +231,7 @@ const BlockDetails: React.FC = () => {
                   {...skeletonProps}
                   title={{ width: isSmallAndLower ? "100%" : "33%" }}
                 >
-                  Ӿ{new BigNumber(balance).toFormat()}
+                  Ӿ {new BigNumber(balance).toFormat()}
                   <br />
                 </Skeleton>
                 <Skeleton
@@ -240,7 +241,7 @@ const BlockDetails: React.FC = () => {
                   }
                   title={{ width: isSmallAndLower ? "100%" : "33%" }}
                 >
-                  {`${CurrencySymbol?.[fiat]}${fiatBalance} / ${btcBalance} BTC`}
+                  {`${CurrencySymbol?.[fiat]} ${fiatBalance} / ${btcBalance} BTC`}
                 </Skeleton>
               </Col>
             </Row>
@@ -355,6 +356,24 @@ const BlockDetails: React.FC = () => {
                 ) : null}
               </Col>
             </Row>
+            {subtype === "receive" ? (
+              <Row gutter={6}>
+                <Col xs={24} sm={6} xl={4}>
+                  {t("pages.block.matchingSendBlock")}
+                </Col>
+                <Skeleton
+                  {...skeletonProps}
+                  title={{ width: isSmallAndLower ? "100%" : "50%" }}
+                ></Skeleton>
+                <Col xs={24} sm={18} xl={20}>
+                  {isValidBlockHash(link) ? (
+                    <Link to={`/block/${link}`} className="break-word">
+                      {link}
+                    </Link>
+                  ) : null}
+                </Col>
+              </Row>
+            ) : null}
             <Row gutter={6}>
               <Col xs={24} sm={6} xl={4}>
                 {t("pages.block.signature")}

--- a/src/pages/DeveloperFund/index.tsx
+++ b/src/pages/DeveloperFund/index.tsx
@@ -143,7 +143,7 @@ const DeveloperFund: React.FC = () => {
                   value={totalBalance}
                 />
                 <Skeleton {...skeletonProps}>
-                  {`${CurrencySymbol?.[fiat]}${fiatBalance} / ${btcBalance} BTC`}
+                  {`${CurrencySymbol?.[fiat]} ${fiatBalance} / ${btcBalance} BTC`}
                 </Skeleton>
               </Col>
             </Row>
@@ -171,7 +171,7 @@ const DeveloperFund: React.FC = () => {
                   loading={!lastTransactionAmount}
                   paragraph={false}
                 >
-                  Ӿ{lastTransactionAmount}
+                  Ӿ {lastTransactionAmount}
                   <br />
                 </Skeleton>
                 <Skeleton
@@ -247,7 +247,7 @@ const DeveloperFund: React.FC = () => {
                 {t("common.balance")}
               </Col>
               <Col xs={24} sm={18}>
-                Ӿ{new BigNumber("7000000").toFormat()}
+                Ӿ {new BigNumber("7000000").toFormat()}
                 <br />
                 {t("pages.developerFund.percentOfTotal", {
                   percent: new BigNumber(7000000 * 100)
@@ -304,7 +304,7 @@ const DeveloperFund: React.FC = () => {
                   display: "block",
                 }}
               >
-                Ӿ{balance}
+                Ӿ {balance}
               </span>
             </Col>
             <Col sm={14} md={14} xl={18}>

--- a/src/pages/Distribution/DormantFunds.tsx
+++ b/src/pages/Distribution/DormantFunds.tsx
@@ -93,16 +93,16 @@ const DormantFunds: React.FC<Props> = ({ data }) => {
             <ul style={{ margin: "12px 0" }}>
               <li>
                 {t("pages.distribution.availableSupply")}:{" "}
-                <strong>Ӿ{new BigNumber(availableSupply).toFormat()}</strong>
+                <strong> Ӿ{new BigNumber(availableSupply).toFormat()}</strong>
               </li>
               <li>
                 {t("pages.distribution.knownAccountBalances")}:{" "}
-                <strong>Ӿ{new BigNumber(totalFunds).toFormat()}</strong>
+                <strong>Ӿ {new BigNumber(totalFunds).toFormat()}</strong>
               </li>
               <li>
                 {t("pages.distribution.unknownDormantFunds")}:{" "}
                 <strong>
-                  Ӿ{new BigNumber(unknownDormantFunds).toFormat()}
+                  Ӿ {new BigNumber(unknownDormantFunds).toFormat()}
                 </strong>
               </li>
             </ul>

--- a/src/pages/Distribution/RichList.tsx
+++ b/src/pages/Distribution/RichList.tsx
@@ -101,7 +101,7 @@ const RichList: React.FC = () => {
                   </Link>
                 </Col>
                 <Col sm={6} md={6} xl={4}>
-                  Ӿ{new BigNumber(balance).toFormat()}
+                  Ӿ {new BigNumber(balance).toFormat()}
                   <span
                     className="color-muted"
                     style={{
@@ -122,7 +122,7 @@ const RichList: React.FC = () => {
                 <Col sm={4} md={4} xl={4}>
                   {currentPrice && btcCurrentPrice ? (
                     <>
-                      {`${CurrencySymbol?.[fiat]}${new BigNumber(balance)
+                      {`${CurrencySymbol?.[fiat]} ${new BigNumber(balance)
                         .times(currentPrice)
                         .toFormat(CurrencyDecimal?.[fiat])}`}
                       <span

--- a/src/pages/Home/RecentTransactions/Timeline.tsx
+++ b/src/pages/Home/RecentTransactions/Timeline.tsx
@@ -60,7 +60,7 @@ const RecentTransactions: React.FC<Props> = ({ recentTransactions }) => {
                 {subtype !== "change" ? (
                   <Text style={{ color }} className="timeline-amount">
                     {amount
-                      ? `Ӿ${new BigNumber(rawToRai(amount)).toFormat()}`
+                      ? `Ӿ ${new BigNumber(rawToRai(amount)).toFormat()}`
                       : t("common.notAvailable")}
                   </Text>
                 ) : null}

--- a/src/pages/KnownAccounts/index.tsx
+++ b/src/pages/KnownAccounts/index.tsx
@@ -41,7 +41,7 @@ const KnownAccountsPage: React.FC = () => {
             },
             render: (text: string) => (
               <span className="break-word">
-                Ӿ{new BigNumber(text).toFormat()}
+                Ӿ {new BigNumber(text).toFormat()}
               </span>
             ),
           },

--- a/src/pages/NetworkStatus/PieChart.tsx
+++ b/src/pages/NetworkStatus/PieChart.tsx
@@ -93,7 +93,7 @@ const Representatives: React.FC<Props> = ({ versions }) => {
         }) => ({
           name: version,
           value: isVersionByWeight
-            ? `Ӿ${new BigNumber(weight).toFormat(2)} - ${new BigNumber(weight)
+            ? `Ӿ ${new BigNumber(weight).toFormat(2)} - ${new BigNumber(weight)
                 .times(100)
                 .dividedBy(totalWeight)
                 .toFormat(2)}%`

--- a/src/pages/Representatives/index.tsx
+++ b/src/pages/Representatives/index.tsx
@@ -212,7 +212,7 @@ const Representatives = () => {
               </Col>
               <Col xs={24} sm={16}>
                 <Skeleton {...confirmationQuorumSkeletonProps}>
-                  Ӿ{new BigNumber(principalRepresentativeMinWeight).toFormat()}
+                  Ӿ {new BigNumber(principalRepresentativeMinWeight).toFormat()}
                 </Skeleton>
               </Col>
             </Row>
@@ -233,7 +233,7 @@ const Representatives = () => {
               <Col xs={24} sm={16}>
                 {" "}
                 <Skeleton {...confirmationQuorumSkeletonProps}>
-                  Ӿ{new BigNumber(rawToRai(onlineWeightMinimum)).toFormat()}
+                  Ӿ {new BigNumber(rawToRai(onlineWeightMinimum)).toFormat()}
                 </Skeleton>
               </Col>
             </Row>
@@ -243,7 +243,7 @@ const Representatives = () => {
               </Col>
               <Col xs={24} sm={16}>
                 <Skeleton {...confirmationQuorumSkeletonProps}>
-                  Ӿ{new BigNumber(rawToRai(onlineStakeTotal)).toFormat(0)}
+                  Ӿ {new BigNumber(rawToRai(onlineStakeTotal)).toFormat(0)}
                 </Skeleton>
               </Col>
             </Row>
@@ -253,7 +253,7 @@ const Representatives = () => {
               </Col>
               <Col xs={24} sm={16}>
                 <Skeleton {...confirmationQuorumSkeletonProps}>
-                  Ӿ{new BigNumber(rawToRai(peersStakeTotal)).toFormat(0)}
+                  Ӿ {new BigNumber(rawToRai(peersStakeTotal)).toFormat(0)}
                 </Skeleton>
               </Col>
             </Row>
@@ -331,7 +331,7 @@ const Representatives = () => {
                           display: "block",
                         }}
                       >
-                        Ӿ{weight}
+                        Ӿ {weight}
                       </span>
 
                       {isPrincipal ? (


### PR DESCRIPTION
Added a small spacing between all currency symbols and the currency amounts for better readability. Also decreased the spacing on `.ant-statistic-content-prefix` for consistency.

Added a "Matching send block" when the block is a receive, so that users can click on the matching send block. This is useful to track some blocks more easily, and also to check whether a block was immediately received after being sent or if there was some delay.
A "Matching receive block" could also be added in a future update, but since that is not efficiently retrievable from the nano node, it wouldn't be as quick to set up, and the computation time it could take on some blocks could make this a bad idea.