### PR TITLE
Added getnano.ovh Faucet to the website

### DIFF
--- a/src/pages/Faucets/faucets.json
+++ b/src/pages/Faucets/faucets.json
@@ -58,5 +58,11 @@
     "alias": "i can haz nano",
     "account": "nano_1monkecrqoqr6j6qzhtd9i8x49ujdnoqt7ramt9jmhd543icsrx5accoqtd5",
     "link": "https://icanhaznano.monke42.tk"
+  },
+  {
+    "alias": "getnano.ovh Faucet",
+    "account": "nano_18e4hwxk48kfy9kjc81hz494z68xa9u5863ain7jwyorqj6tjwhxibx4rzqu",
+    "link": "https://getnano.ovh"
   }
+  
 ]


### PR DESCRIPTION
Added getnano.ovh
It's an unpopular faucet as of now. I started it ~yesterday and it's already featured on hub.nano.org/faucets and a bunch of other faucet hubs, and yes it is all in lowercase. I personally think getnano.ovh looks better than GetNano.ovh

Thanks in advance