### PR TITLE
chore(faucets): update getnano.ovh address to its new one

### DIFF
--- a/src/pages/Faucets/faucets.json
+++ b/src/pages/Faucets/faucets.json
@@ -46,7 +46,7 @@
   },
   {
     "alias": "getnano.ovh Faucet",
-    "account": "nano_18e4hwxk48kfy9kjc81hz494z68xa9u5863ain7jwyorqj6tjwhxibx4rzqu",
+    "account": "nano_3getnanons1aaqo5itbm8wdbzhtsp7tctd6p6qa7axwff7ocemzs3w381kfy",
     "link": "https://getnano.ovh"
   },
   {


### PR DESCRIPTION
I am the owner of getnano.ovh faucet and I recently started using new backend, with that change I also changed faucet's address to a vanity one.